### PR TITLE
2 read contract content

### DIFF
--- a/cmd/inputs/main.go
+++ b/cmd/inputs/main.go
@@ -1,20 +1,84 @@
 package main
 
 import (
-	"fmt"
+	"context"
 	"os"
+	"strings"
 
 	"github.com/dogefuzz/inputs/pkg/common"
+	"github.com/dogefuzz/inputs/pkg/solc"
+	"github.com/dogefuzz/inputs/pkg/vandal"
 )
 
 func main() {
-	fmt.Println("Hello World")
+	contractSlice := make([]common.ContractInfo, 0)
+	data := make([][]string, 0)
 
-	data := common.ReadCsvFile(os.Args[1])
+	data = common.ReadCsvFile(os.Args[1])
 
-	contractSlice := createContractSlice(data)
+	contractSlice = createContractSlice(data)
 
-	fmt.Println(contractSlice)
+	for i := 0; i < len(contractSlice); i++ {
+		contractContent, err := readContractContent(contractSlice[i].Name)
+
+		if err == nil {
+			contractName := strings.Split(contractSlice[i].Name, ".")
+
+			blocks, predecessors, criticalInstructions := getNumberOfBlocksAndCriticalInstructions(contractName[0], contractContent)
+
+			setNumberOfBlocks(&contractSlice[i], blocks)
+			setNumberOfPredecessors(&contractSlice[i], predecessors)
+			setNumberOfCriticalInstructions(&contractSlice[i], criticalInstructions)
+		}
+	}
+}
+
+func setNumberOfBlocks(contract *common.ContractInfo, numberOfBlocks int) {
+	contract.NumberOfBlocks = numberOfBlocks
+}
+
+func setNumberOfPredecessors(contract *common.ContractInfo, numberOfPredecessors int) {
+	contract.NumberOfPredecessors = numberOfPredecessors
+}
+
+func setNumberOfCriticalInstructions(contract *common.ContractInfo, numberOfCriticalInstructions int) {
+	contract.NumberOfCriticalInstructions = numberOfCriticalInstructions
+}
+
+func getNumberOfBlocksAndCriticalInstructions(contractName string, contractContent string) (int, int, int) {
+	var nos, arestas, instrucoes int
+
+	compiler := solc.NewSolidityCompiler("/tmp/dogefuzz/")
+	name := strings.Split(contractName, ".")
+	contract, _ := compiler.CompileSource(name[0], contractContent)
+
+	c := vandal.NewVandalClient("http://localhost:5005")
+	blocks, _, _ := c.Decompile(context.Background(), contract.CompiledCode)
+
+	nos = len(blocks)
+	for _, block := range blocks {
+		arestas += len(block.Predecessors)
+		for _, v := range block.Instructions {
+			switch v.Op {
+			case "CALL":
+				instrucoes++
+			case "SELFDESTRUCT":
+				instrucoes++
+			case "CALLCODE":
+				instrucoes++
+			case "DELEGATECALL":
+				instrucoes++
+			}
+		}
+	}
+
+	return nos, arestas, instrucoes
+}
+
+func readContractContent(contractName string) (string, error) {
+	data, err := os.ReadFile("contracts/" + contractName)
+
+	return string(data), err
 }
 
 func createContractSlice(data [][]string) []common.ContractInfo {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -32,10 +32,10 @@ type Function struct {
 }
 
 type ContractInfo struct {
-	Name                         string   `json:"name"`
-	Weaknesses                   []string `json:"weaknesses"`
-	Link                         string   `json:"link"`
-	NumberOfBlocks               int      `json:"numberOfBlocks"`
-	NumberOfPredecessors         int      `json:"numberOfPredecessors"`
-	NumberOfCriticalInstructions int      `json:"numberOfCriticalInstructions"`
+	Name                         string         `json:"name"`
+	Weaknesses                   []string       `json:"weaknesses"`
+	Link                         string         `json:"link"`
+	NumberOfBlocks               int            `json:"numberOfBlocks"`
+	NumberOfBranches             int            `json:"numberOfBranches"`
+	NumberOfCriticalInstructions map[string]int `json:"numberOfCriticalInstructions"`
 }

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -32,7 +32,10 @@ type Function struct {
 }
 
 type ContractInfo struct {
-	Name       string   `json:"name"`
-	Weaknesses []string `json:"weaknesses"`
-	Link       string   `json:"string"`
+	Name                         string   `json:"name"`
+	Weaknesses                   []string `json:"weaknesses"`
+	Link                         string   `json:"link"`
+	NumberOfBlocks               int      `json:"numberOfBlocks"`
+	NumberOfPredecessors         int      `json:"numberOfPredecessors"`
+	NumberOfCriticalInstructions int      `json:"numberOfCriticalInstructions"`
 }


### PR DESCRIPTION
A method to returns the content of the contract file as a string.
A method to returns the number of blocks, predecessors, and critical instructions.
Some methods store the number of blocks, predecessors, and critical instructions into the ContractInfo struct